### PR TITLE
行があふれないように分割

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -7,6 +7,7 @@ html {
   font-size: 112.5%;
   @apply antialiased;
   @apply mx-4;
+  overflow-wrap: break-word;
 }
 
 h2 {


### PR DESCRIPTION
cf. [overflow-wrap - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/overflow-wrap)

```css
overflow-wrap: break-word;
```